### PR TITLE
Fix issues

### DIFF
--- a/src/Be.Stateless.Dsl.Configuration.Cmdlets/Cmdlets/MergeConfigurationSpecification.cs
+++ b/src/Be.Stateless.Dsl.Configuration.Cmdlets/Cmdlets/MergeConfigurationSpecification.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License
 
-// Copyright © 2012 - 2020 François Chabot & Emmanuel Benitez
+// Copyright © 2012 - 2021 François Chabot & Emmanuel Benitez
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ namespace Be.Stateless.Dsl.Configuration.Cmdlets
                     string.Empty))
                 {
                     if (SaveBeforeMerge) File.Copy(specification.TargetConfigurationFile.FullName, GenerateFilePath(specification.TargetConfigurationFile, "before"));
-                    using (var fileStream = specification.TargetConfigurationFile.OpenWrite()) result.ModifiedConfiguration.Save(fileStream);
+                    using (var fileStream = new FileStream(specification.TargetConfigurationFile.FullName, FileMode.Truncate)) result.ModifiedConfiguration.Save(fileStream);
                     WriteVerbose($"'{specification.TargetConfigurationFile.FullName}' has been updated.");
                     if (GenerateUndo)
                     {

--- a/src/Be.Stateless.Dsl.Configuration/Commands/ElementDeletionCommand.cs
+++ b/src/Be.Stateless.Dsl.Configuration/Commands/ElementDeletionCommand.cs
@@ -30,8 +30,8 @@ namespace Be.Stateless.Dsl.Configuration.Commands
 
         internal override ConfigurationCommand Execute(XmlElement configurationElement)
         {
-            if (!configurationElement.IsEmpty)
-                throw new InvalidOperationException($"The configuration element '{configurationElement.Name}' is not empty (Content: '{configurationElement.InnerXml}').");
+            if (configurationElement.HasChildNodes)
+                throw new InvalidOperationException($"The configuration element '{configurationElement.Name}' has child nodes (Content: '{configurationElement.InnerXml}').");
 
             var undoCommand = ConfigurationCommandFactory.CreateUndoCommandForDeletion(configurationElement);
             var parent = configurationElement.ParentNode

--- a/src/Be.Stateless.Dsl.Configuration/Extensions/XmlNodeExtensions.cs
+++ b/src/Be.Stateless.Dsl.Configuration/Extensions/XmlNodeExtensions.cs
@@ -48,7 +48,7 @@ namespace Be.Stateless.Dsl.Configuration.Extensions
                     XmlAttributeNames.DISCRIMINANT,
                     Constants.NAMESPACE_URI,
                     Constants.NAMESPACE_URI_PREFIX,
-                    string.Join(Constants.DISCRIMINANT_SEPARATOR.ToString(), locationStep.AttributeSpecifications.Select(specification => specification.Value)));
+                    string.Join(Constants.DISCRIMINANT_SEPARATOR.ToString(), locationStep.AttributeSpecifications.Select(specification => specification.Name)));
             }
             return element;
         }

--- a/src/Be.Stateless.Dsl.Configuration/XPath/XPathBuilder.cs
+++ b/src/Be.Stateless.Dsl.Configuration/XPath/XPathBuilder.cs
@@ -36,7 +36,7 @@ namespace Be.Stateless.Dsl.Configuration.XPath
                     return navigator.Name;
                 case XPathFormat.LocalName:
                     var builder = new StringBuilder("*[");
-                    builder.AppendFormat($"{XpathFunctionNames.LOCAL_NAME}()='{0}'", navigator.LocalName);
+                    builder.Append($"{XpathFunctionNames.LOCAL_NAME}()='{navigator.LocalName}'");
                     if (!string.IsNullOrWhiteSpace(navigator.NamespaceURI)) builder.AppendFormat(" and namespace-uri()='{0}'", navigator.NamespaceURI);
                     var discriminants = navigator.GetDiscriminants().ToArray();
                     if (discriminants.Any()) builder.AppendFormat(" and ({0})", BuildDiscriminantsSelector(navigator, discriminants));


### PR DESCRIPTION
Fix the following the issues:

1. Truncate the target configuration file before saving modifications because when the modified content is shorter than the orginal the saved file contains the end of the previous content
2. During the element deletion, the command checks the property IsEmpty of the XmlElement instead of the property HasChildNodes
3.  In the discriminant generation (when the configuration specification is written) used the name instead of the value
4. During the node path building, the format is wrong due to the usage of string interpolation